### PR TITLE
fix: allow for repeated query parameters.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@harver/bat",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/steps-fn.js
+++ b/src/steps-fn.js
@@ -118,7 +118,11 @@ function makeGraphQLRequest(query) {
 }
 
 function addQueryString(qs) {
-    const queryObject = qs.rowsHash();
+    const queryObject = qs.raw().reduce((acc, [key, value]) => {
+        const previousEntry = acc[key];
+        acc[key] = previousEntry ? [].concat(...[previousEntry, value]) : value;
+        return acc;
+      }, {});
     this.req.query(queryObject);
 }
 

--- a/src/steps.js
+++ b/src/steps.js
@@ -615,8 +615,10 @@ function registerSteps({ Given, When, Then }) {
      * @function printRequest
      */
     Then('print the request', async function () {
-        this.debug.push(`[debug] Showing request details for "${this.req.method}" to "${this.req.url}":\n`);
-        this.debug.push(JSON.stringify(this.req, null, '  '));
+        const req = this.replaceVariablesInitiator()(this.req);
+        this.debug.push(`[debug] Showing request details for "${req.method}" to "${req.url}":\n`);
+        const { method, url, headers, qs, _data: data } = req;
+        this.debug.push(JSON.stringify({ method, url, headers, qs, data }, null, '  '));
     });
 
     /**

--- a/test/features/test-steps-short.feature
+++ b/test/features/test-steps-short.feature
@@ -27,9 +27,11 @@ Feature: API Testing Steps
   Scenario: Testing Gets
     When GET "{base}/pets"
     And qs:
-      | sort   | desc        |
-      | filter | {color}     |
-      | time   | {timestamp} |
+      | sort     | desc        |
+      | filter   | {color}     |
+      | time     | {timestamp} |
+      | select[] | name        |
+      | select[] | age         |
     And set cookie:
       | Name | Value | Flags  |
       | foo  | bar   | path=/ |
@@ -91,9 +93,11 @@ Feature: API Testing Steps
   Scenario: Testing Alternative Table Syntax for multiples
     When GET "{base}/pets"
     And qs:
-      | sort   | desc        |
-      | filter | red         |
-      | time   | {timestamp} |
+      | sort     | desc        |
+      | filter   | red         |
+      | time     | {timestamp} |
+      | select[] | name        |
+      | select[] | age         |
     And set cookies:
       | Name | Value | Flags  |
       | foo  | bar   | path=/ |

--- a/test/features/test-steps.feature
+++ b/test/features/test-steps.feature
@@ -27,9 +27,11 @@ Feature: API Testing Steps
   Scenario: Testing Gets
     When GET "{base}/pets"
     And I add the query string parameters:
-      | sort   | desc        |
-      | filter | {color}     |
-      | time   | {timestamp} |
+      | sort     | desc        |
+      | filter   | {color}     |
+      | time     | {timestamp} |
+      | select[] | name        |
+      | select[] | age         |
     And I set the cookie:
       | Name | Value | Flags  |
       | foo  | bar   | path=/ |
@@ -91,9 +93,11 @@ Feature: API Testing Steps
   Scenario: Testing Alternative Table Syntax for multiples
     When I send a 'GET' request to '{base}/pets'
     And I add the query string parameters:
-      | sort   | desc        |
-      | filter | red         |
-      | time   | {timestamp} |
+      | sort     | desc        |
+      | filter   | red         |
+      | time     | {timestamp} |
+      | select[] | name        |
+      | select[] | age         |
     And I set the cookies:
       | Name | Value | Flags  |
       | foo  | bar   | path=/ |

--- a/test/server.js
+++ b/test/server.js
@@ -53,6 +53,7 @@ app.get('/pets', (req, res, next) => {
         deepEqual(req.cookies, { foo: 'bar', path: '/' });
         equal(req.query.sort, 'desc');
         equal(req.query.filter, 'red');
+        deepEqual(req.query.select, ['name', 'age']);
         equal(isNaN(parseInt(req.query.time)), false);
 
         // force a tiny bit of latency to test the LATENCY_BUFFER config


### PR DESCRIPTION
Currently the following case is not covered:

```
When qs:
      | select          | fullName |
      | select          | score    |
      | select          | created  |
      | select          | source   |
```

Only the last `select` parameter will be passed to the request.

This change will take the raw values from the query-string table and create arrays for duplicate keys.

I also changed to step for `print the request` to show query-string and replaced vars